### PR TITLE
Fix: Prevent Playwright tests from polluting Google Analytics data

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -427,20 +427,40 @@ const {
       });
     </script>
 
-    <!-- Google Analytics -->
-    <script
-      is:inline
-      async
-      src="https://www.googletagmanager.com/gtag/js?id=G-M063F7X189"></script>
-    <script is:inline>
-      window.dataLayer = window.dataLayer || [];
-      function gtag() {
-        dataLayer.push(arguments);
-      }
-      gtag('js', new Date());
-      gtag('config', 'G-M063F7X189', {
-        anonymize_ip: true,
-      });
-    </script>
+    <!-- Google Analytics (Production Only) -->
+    {
+      import.meta.env.PROD && (
+        <>
+          <script
+            is:inline
+            async
+            src="https://www.googletagmanager.com/gtag/js?id=G-M063F7X189"
+          />
+          <script
+            is:inline
+            set:html={`
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+            gtag('config', 'G-M063F7X189', {
+              anonymize_ip: true,
+            });
+          `}
+          />
+        </>
+      )
+    }
+
+    <!-- Stub gtag function for non-production to prevent errors -->
+    {
+      !import.meta.env.PROD && (
+        <script
+          is:inline
+          set:html={`
+          window.gtag = function () {};
+        `}
+        />
+      )
+    }
   </body>
 </html>

--- a/tests/blog.spec.ts
+++ b/tests/blog.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './global-setup';
 
 type LanguageConfig = {
   locale: string;

--- a/tests/global-setup.ts
+++ b/tests/global-setup.ts
@@ -1,0 +1,13 @@
+import { test as base } from '@playwright/test';
+
+// Extend base test to block Google Analytics routes
+export const test = base.extend({
+  page: async ({ page }, use) => {
+    // Block Google Analytics domains to prevent test traffic pollution
+    await page.route('**/*google-analytics.com/**', (route) => route.abort());
+    await page.route('**/*googletagmanager.com/**', (route) => route.abort());
+    await use(page);
+  },
+});
+
+export { expect } from '@playwright/test';

--- a/tests/i18n.spec.ts
+++ b/tests/i18n.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './global-setup';
 
 type LocaleConfig = {
   url: string;


### PR DESCRIPTION
## Summary

Implemented a two-layer defense system to prevent E2E test traffic from polluting production Google Analytics data.

### Problem

Playwright tests were sending test traffic to the production GA property (G-M063F7X189), polluting analytics data with:
- Page views from every `page.goto()` call
- Language switch events from i18n tests
- Email/phone/social click tracking
- Section visibility events
- CV download tracking
- Every test run on CI multiplies the pollution

### Solution

**Layer 1: Environment-Based Loading**
- GA scripts only load when `import.meta.env.PROD === true`
- Added stub `gtag` function for non-production to prevent errors
- Uses Astro's built-in environment variable (no custom config needed)

**Layer 2: Network-Level Blocking**
- Created Playwright fixture (`tests/global-setup.ts`) that blocks GA domains
- Extends base test to abort routes to `google-analytics.com` and `googletagmanager.com`
- Applies automatically to all tests that import the custom fixture
- Follows official Playwright best practices for global setup

### Changes

- `src/layouts/Layout.astro`: Wrapped GA scripts in production check using `set:html`
- `tests/global-setup.ts`: New fixture with route blocking (Playwright best practice)
- `tests/blog.spec.ts`: Import from custom fixture
- `tests/i18n.spec.ts`: Import from custom fixture

### Testing

✅ **All 59 E2E tests pass** (12.3s)  
✅ **Type check**: 0 errors  
✅ **Production build**: Successful  
✅ **Pre-commit hooks**: ESLint, Prettier, TypeScript all passed  

### Verification

**Development (GA should NOT load):**
```bash
pnpm dev
# DevTools → Network → No requests to google-analytics.com
```

**Production (GA SHOULD load):**
```bash
pnpm build && pnpm preview
# DevTools → Network → Requests to google-analytics.com present
```

### Post-Deployment Checklist

- [ ] Verify GA loads in production (check DevTools Network tab on live site)
- [ ] Monitor GA real-time reports to ensure legitimate traffic is tracked
- [ ] Confirm no test traffic appears in GA after CI runs

Resolves #8