### PR TITLE
fix(tests): stabilize flaky 'months ago' relative time test

### DIFF
--- a/tests/unit/utils/dateFormatting.test.ts
+++ b/tests/unit/utils/dateFormatting.test.ts
@@ -93,7 +93,9 @@ describe('formatRelativeTime', () => {
 
   it('formats months ago in English', () => {
     const twoMonthsAgo = new Date();
-    twoMonthsAgo.setMonth(twoMonthsAgo.getMonth() - 2);
+    // Use 65 days to ensure Math.floor(diffDays / 30) === 2 regardless of
+    // the current calendar month's length (setMonth(-2) can yield 59 days).
+    twoMonthsAgo.setDate(twoMonthsAgo.getDate() - 65);
     const formatted = formatRelativeTime(twoMonthsAgo, 'en');
     expect(formatted).toContain('2 months ago');
   });


### PR DESCRIPTION
## Summary
- Fixes the `unit-tests` CI failure on `main` introduced by commit 38f736c (PR #50).
- The test `formats months ago in English` used `setMonth(-2)`, which on 2026-04-16 yields 2026-02-16 — only **59 days** back (Feb 2026 has 28 days). `formatRelativeTime` buckets by `Math.floor(diffDays / 30)`, so it rounded to 1 and `Intl.RelativeTimeFormat` returned `"last month"` instead of `"2 months ago"`.
- Switched the offset to a fixed `setDate(-65)` so the bucket is always 2, regardless of the calendar month we happen to be in.

## Why not fix the formatter instead?
The formatter's days/30 heuristic is used elsewhere and is fine for display; the bug is purely test flakiness around calendar-short months. A scoped test fix keeps the blast radius minimal.

## Test plan
- [x] `pnpm test:unit` — 118/118 passing locally
- [ ] CI green on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved stability of relative date formatting test cases to account for varying month lengths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->