### PR TITLE
feat(blog): newsletter subscribe form

### DIFF
--- a/docs/proposals/newsletter-status.md
+++ b/docs/proposals/newsletter-status.md
@@ -4,14 +4,19 @@
 
 ## Architecture (deployed)
 
-```
+```text
 Astro site (Netlify)
-  └── <SubscribeForm lang> [PHASE 3 — pending]
-        └── POST /api/subscribe (Astro server endpoint)
-              └── HTTPS + Basic Auth → Listmonk API on Pi
+  └── <SubscribeForm lang>
+        ├── altcha-widget fetches challenge cross-origin from Listmonk (CORS allowed)
+        └── HTML form POST cross-origin → newsletter.jjuanrivvera.com/subscription/form
+              └── Listmonk on Pi (Docker, behind home tunnel)
                     └── SMTP via Resend (smtp.resend.com:465 SSL)
                           └── Resend → Amazon SES → recipient inbox
 ```
+
+No first-party Astro server endpoint. Listmonk's hosted form handler accepts
+the cross-origin POST directly; browsers don't require CORS for plain HTML
+form submits.
 
 ## Phase 1 — DNS + Resend (DONE)
 
@@ -73,22 +78,19 @@ Resend domain `jjuanrivvera.com` verified. Send-only API key stored.
 - Cadence: per-post (one email per new blog post)
 - Welcome email: generic
 - Listmonk on: Pi (not VPS)
-- Turnstile on subscribe form: yes from day 1
+- Captcha on subscribe form: **Altcha** (built-in Listmonk; chosen over Turnstile because Listmonk doesn't natively support Turnstile and Altcha needs no third-party signup or server-side validation)
 
-## Phase 3 — Astro integration (PENDING)
+## Phase 3 — Astro integration (DONE)
 
-Tasks:
+Shipped:
 
-1. Build `<SubscribeForm lang={lang} />` Vue/Astro component
-2. Place in blog post layouts (bottom of post) and site footer
-3. Server endpoint at `/api/subscribe` — POST receives `{email, lang}`, calls Listmonk API
-4. Listmonk API token held in Netlify env var (never exposed to browser)
-5. Cloudflare Turnstile token verified server-side
-6. Language → list ID mapping:
-   - `en` → list id 3
-   - `es` → list id 4
-   - `pt` → list id 5
-7. Success page with double-opt-in instructions
+1. `<SubscribeForm lang={lang} />` reusable Astro component (`src/components/blog/SubscribeForm.astro`)
+2. Placed in blog post layouts after `<AuthorBio>`
+3. **HTML form POST cross-origin** to `https://newsletter.jjuanrivvera.com/subscription/form` — no server endpoint, no Listmonk API token in browser
+4. Per-language hidden input `l` carries the matching list UUID
+5. Altcha widget fetches challenge from `/api/public/captcha/altcha` (CORS: `https://jjuanrivvera.com`, `https://www.jjuanrivvera.com`)
+6. Listmonk validates the altcha solution server-side and sends the double-opt-in email
+7. Response renders on Listmonk's hosted page in a new tab (`target="_blank"`) so the reader keeps their place in the post
 
 ## Phase 4 — Content workflow (PENDING)
 

--- a/docs/proposals/newsletter-status.md
+++ b/docs/proposals/newsletter-status.md
@@ -1,0 +1,108 @@
+# Newsletter — Implementation Status
+
+**Last updated**: 2026-04-25
+
+## Architecture (deployed)
+
+```
+Astro site (Netlify)
+  └── <SubscribeForm lang> [PHASE 3 — pending]
+        └── POST /api/subscribe (Astro server endpoint)
+              └── HTTPS + Basic Auth → Listmonk API on Pi
+                    └── SMTP via Resend (smtp.resend.com:465 SSL)
+                          └── Resend → Amazon SES → recipient inbox
+```
+
+## Phase 1 — DNS + Resend (DONE)
+
+DNS records on `jjuanrivvera.com` zone:
+
+- `_dmarc` TXT — DMARC `p=none` monitoring; tighten to `quarantine` after 2w clean, `reject` after 6w
+- `resend._domainkey` TXT — DKIM key from Resend
+- `send.jjuanrivvera.com` TXT — `v=spf1 include:amazonses.com ~all` (isolated subdomain SPF)
+- `send.jjuanrivvera.com` MX → `feedback-smtp.sa-east-1.amazonses.com` (return-path)
+- Email Routing rule: `dmarc@jjuanrivvera.com` → forwards to `jjuanrivvera@gmail.com` (DMARC reports)
+
+Root SPF unchanged (still strict CF Email Routing only).
+
+Resend domain `jjuanrivvera.com` verified. Send-only API key stored.
+
+## Phase 2 — Listmonk on Pi (DONE)
+
+**Deployment**:
+
+- Pi `~/services/listmonk/` — Docker Compose (Listmonk v6.1.0 + Postgres 17 alpine)
+- Listmonk container binds `127.0.0.1:9020`, Postgres `127.0.0.1:9001`
+- Restart policy: `unless-stopped`
+- Public URL: `https://newsletter.jjuanrivvera.com` (via home tunnel, version 76)
+- Whitelisted in CF "Not in colombia" geo-fence (subscribers reachable globally)
+
+**Bootstrap quirk** (documented for future ref):
+
+- Listmonk v6.1.0 setup wizard has a bug — inserts admin with `user_role_id=NULL` violating NOT NULL constraint.
+- Workaround applied: created Super Admin role + admin user via SQL with the bcrypt hash that Listmonk's bootstrap had generated (extracted from the failed insert error message).
+- IMPORTANT: SSH heredoc mangles `$2a$06$...` bcrypt prefixes — always pass via `scp` of a SQL file, never inline.
+
+**Configuration**:
+
+- SMTP server: Resend (smtp.resend.com:465, SSL/TLS, auth=LOGIN, user=resend, password=Resend API key)
+- Default sender: `newsletter@jjuanrivvera.com`
+
+**Lists** (all double opt-in, public):
+| ID | Name | UUID |
+|---|---|---|
+| 3 | Newsletter (English) | `1fd370d2-9c78-4e9d-98a2-9313fd5a0061` |
+| 4 | Newsletter (Español) | `99da3660-a828-409c-8ad4-a5631ab09cb6` |
+| 5 | Newsletter (Português) | `97112328-d358-4ecf-bb43-33a63731a11b` |
+
+**Users**:
+
+- `admin` (type=user, role=Super Admin) — web login
+- `astro` (type=api, role=Super Admin) — for Astro integration
+
+## Credentials (stored on VPS, never in repo)
+
+- Admin password: `~/.listmonk-admin-pass` (chmod 600)
+- API user "astro" token: `~/.listmonk-api-token` (chmod 600)
+- Resend API key (send-only): `~/.resend-api-key` (chmod 600)
+- Listmonk Postgres password: `~/services/listmonk/.env` on Pi (chmod 600)
+
+## Decisions (per Juan 2026-04-24)
+
+- From address: `newsletter@jjuanrivvera.com`
+- Cadence: per-post (one email per new blog post)
+- Welcome email: generic
+- Listmonk on: Pi (not VPS)
+- Turnstile on subscribe form: yes from day 1
+
+## Phase 3 — Astro integration (PENDING)
+
+Tasks:
+
+1. Build `<SubscribeForm lang={lang} />` Vue/Astro component
+2. Place in blog post layouts (bottom of post) and site footer
+3. Server endpoint at `/api/subscribe` — POST receives `{email, lang}`, calls Listmonk API
+4. Listmonk API token held in Netlify env var (never exposed to browser)
+5. Cloudflare Turnstile token verified server-side
+6. Language → list ID mapping:
+   - `en` → list id 3
+   - `es` → list id 4
+   - `pt` → list id 5
+7. Success page with double-opt-in instructions
+
+## Phase 4 — Content workflow (PENDING)
+
+- Trigger: blog PR merge to main
+- Action: GitHub Action runs Listmonk campaign API to send the new post to the matching language list
+- Template per language with site branding
+
+## Phase 5 — Hardening (6 weeks out)
+
+- DMARC `p=none` → `p=quarantine` (2w) → `p=reject` (6w)
+- List cleanup automation (auto-remove hard-bounced emails)
+- Bounce handling via SES SNS (optional)
+
+## Phase 6 — Future upgrades
+
+- If list grows past Resend's free 3k/month: migrate to Brevo (9k free) or AWS SES production
+- All migration paths preserve Listmonk as the data layer

--- a/src/components/blog/SubscribeForm.astro
+++ b/src/components/blog/SubscribeForm.astro
@@ -28,6 +28,10 @@ const listUuids = {
 
 const listUuid = listUuids[lang];
 const listmonkUrl = 'https://newsletter.jjuanrivvera.com/subscription/form';
+const altchaChallengeUrl =
+  'https://newsletter.jjuanrivvera.com/api/public/captcha/altcha';
+const altchaScriptUrl =
+  'https://newsletter.jjuanrivvera.com/public/static/altcha.umd.js';
 ---
 
 <aside class="subscribe-form" aria-labelledby="subscribe-heading">
@@ -64,10 +68,18 @@ const listmonkUrl = 'https://newsletter.jjuanrivvera.com/subscription/form';
         </button>
       </div>
 
+      <altcha-widget
+        challengeurl={altchaChallengeUrl}
+        class="subscribe-form__altcha"
+        hidefooter
+        hidelogo></altcha-widget>
+
       <p class="subscribe-form__hint">{t('newsletter.hint')}</p>
     </form>
   </div>
 </aside>
+
+<script is:inline src={altchaScriptUrl} type="module" async></script>
 
 <style>
   .subscribe-form {
@@ -169,6 +181,15 @@ const listmonkUrl = 'https://newsletter.jjuanrivvera.com/subscription/form';
     margin: 0;
     font-size: 0.85rem;
     color: rgb(100, 116, 139);
+  }
+
+  .subscribe-form__altcha {
+    --altcha-border-color: rgba(99, 102, 241, 0.3);
+    --altcha-color-base: rgba(15, 23, 42, 0.6);
+    --altcha-color-text: rgb(226, 232, 240);
+    --altcha-color-border-focus: rgb(99, 102, 241);
+    margin: 4px auto 0;
+    max-width: 100%;
   }
 
   @media (max-width: 540px) {

--- a/src/components/blog/SubscribeForm.astro
+++ b/src/components/blog/SubscribeForm.astro
@@ -1,0 +1,187 @@
+---
+/**
+ * SubscribeForm Component
+ *
+ * Newsletter subscription form with per-language Listmonk list routing.
+ * Submits cross-origin to https://newsletter.jjuanrivvera.com/subscription/form
+ * (HTML form POST allowed by browsers across origins without CORS).
+ *
+ * Listmonk handles the response page (success / already subscribed / error).
+ * Double opt-in: subscribers receive a confirmation email before being added.
+ */
+
+import { useTranslations } from '@i18n/utils';
+
+interface Props {
+  lang?: 'en' | 'es' | 'pt';
+}
+
+const { lang = 'en' } = Astro.props;
+const t = useTranslations(lang);
+
+// Listmonk list UUIDs per language
+const listUuids = {
+  en: '1fd370d2-9c78-4e9d-98a2-9313fd5a0061',
+  es: '99da3660-a828-409c-8ad4-a5631ab09cb6',
+  pt: '97112328-d358-4ecf-bb43-33a63731a11b',
+} as const;
+
+const listUuid = listUuids[lang];
+const listmonkUrl = 'https://newsletter.jjuanrivvera.com/subscription/form';
+---
+
+<aside class="subscribe-form" aria-labelledby="subscribe-heading">
+  <div class="subscribe-form__inner">
+    <h3 id="subscribe-heading" class="subscribe-form__heading">
+      {t('newsletter.heading')}
+    </h3>
+    <p class="subscribe-form__intro">{t('newsletter.intro')}</p>
+
+    <form
+      method="POST"
+      action={listmonkUrl}
+      class="subscribe-form__form"
+      target="_blank"
+    >
+      <input type="hidden" name="l" value={listUuid} />
+      <input type="hidden" name="nonce" value="" />
+
+      <div class="subscribe-form__row">
+        <label for="newsletter-email" class="subscribe-form__label sr-only">
+          {t('newsletter.emailLabel')}
+        </label>
+        <input
+          id="newsletter-email"
+          type="email"
+          name="email"
+          required
+          placeholder={t('newsletter.emailPlaceholder')}
+          autocomplete="email"
+          class="subscribe-form__input"
+        />
+        <button type="submit" class="subscribe-form__button">
+          {t('newsletter.submit')}
+        </button>
+      </div>
+
+      <p class="subscribe-form__hint">{t('newsletter.hint')}</p>
+    </form>
+  </div>
+</aside>
+
+<style>
+  .subscribe-form {
+    margin-top: 48px;
+    padding: 28px;
+    background: rgba(30, 41, 59, 0.4);
+    border: 1px solid rgba(99, 102, 241, 0.2);
+    border-radius: 12px;
+  }
+
+  .subscribe-form__inner {
+    max-width: 560px;
+    margin: 0 auto;
+    text-align: center;
+  }
+
+  .subscribe-form__heading {
+    margin: 0 0 8px;
+    font-size: 1.4rem;
+    font-weight: 600;
+    color: rgb(226, 232, 240);
+  }
+
+  .subscribe-form__intro {
+    margin: 0 0 20px;
+    color: rgb(148, 163, 184);
+    font-size: 0.95rem;
+    line-height: 1.5;
+  }
+
+  .subscribe-form__form {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .subscribe-form__row {
+    display: flex;
+    gap: 8px;
+    align-items: stretch;
+  }
+
+  .subscribe-form__label.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  .subscribe-form__input {
+    flex: 1;
+    padding: 12px 16px;
+    font-size: 1rem;
+    color: rgb(226, 232, 240);
+    background: rgba(15, 23, 42, 0.6);
+    border: 1px solid rgba(99, 102, 241, 0.3);
+    border-radius: 8px;
+    transition: border-color 0.2s ease;
+  }
+
+  .subscribe-form__input:focus {
+    outline: none;
+    border-color: rgb(99, 102, 241);
+  }
+
+  .subscribe-form__input::placeholder {
+    color: rgb(100, 116, 139);
+  }
+
+  .subscribe-form__button {
+    padding: 12px 24px;
+    font-size: 1rem;
+    font-weight: 600;
+    color: white;
+    background: rgb(99, 102, 241);
+    border: none;
+    border-radius: 8px;
+    cursor: pointer;
+    transition:
+      background 0.2s ease,
+      transform 0.1s ease;
+    white-space: nowrap;
+  }
+
+  .subscribe-form__button:hover {
+    background: rgb(79, 82, 220);
+  }
+
+  .subscribe-form__button:active {
+    transform: scale(0.98);
+  }
+
+  .subscribe-form__hint {
+    margin: 0;
+    font-size: 0.85rem;
+    color: rgb(100, 116, 139);
+  }
+
+  @media (max-width: 540px) {
+    .subscribe-form {
+      padding: 20px;
+    }
+
+    .subscribe-form__row {
+      flex-direction: column;
+    }
+
+    .subscribe-form__button {
+      width: 100%;
+    }
+  }
+</style>

--- a/src/i18n/ui.ts
+++ b/src/i18n/ui.ts
@@ -409,7 +409,7 @@ export const ui = {
     '404.cta': 'Ir al Inicio',
 
     // Newsletter
-    'newsletter.heading': 'Recibí los nuevos posts en tu bandeja',
+    'newsletter.heading': 'Recibe los nuevos posts en tu bandeja',
     'newsletter.intro':
       'Notas prácticas sobre desarrollo asistido por IA, herramientas y los sistemas detrás. Un email cuando sale un post nuevo, sin spam.',
     'newsletter.emailLabel': 'Correo electrónico',

--- a/src/i18n/ui.ts
+++ b/src/i18n/ui.ts
@@ -206,6 +206,16 @@ export const ui = {
     '404.description':
       "The page you're looking for doesn't exist or has been moved.",
     '404.cta': 'Go Home',
+
+    // Newsletter
+    'newsletter.heading': 'Get new posts in your inbox',
+    'newsletter.intro':
+      'Practical notes on AI-assisted development, tooling, and the systems behind them. One email when a new post drops, no spam.',
+    'newsletter.emailLabel': 'Email address',
+    'newsletter.emailPlaceholder': 'you@email.com',
+    'newsletter.submit': 'Subscribe',
+    'newsletter.hint':
+      "You'll get a confirmation email to verify the address. Unsubscribe any time.",
   },
 
   es: {
@@ -397,6 +407,16 @@ export const ui = {
     '404.title': 'Página No Encontrada',
     '404.description': 'La página que buscas no existe o ha sido movida.',
     '404.cta': 'Ir al Inicio',
+
+    // Newsletter
+    'newsletter.heading': 'Recibí los nuevos posts en tu bandeja',
+    'newsletter.intro':
+      'Notas prácticas sobre desarrollo asistido por IA, herramientas y los sistemas detrás. Un email cuando sale un post nuevo, sin spam.',
+    'newsletter.emailLabel': 'Correo electrónico',
+    'newsletter.emailPlaceholder': 'tu@email.com',
+    'newsletter.submit': 'Suscribirme',
+    'newsletter.hint':
+      'Recibirás un email para confirmar la dirección. Te puedes desuscribir cuando quieras.',
   },
   pt: {
     // Meta
@@ -585,6 +605,16 @@ export const ui = {
     '404.title': 'Página Não Encontrada',
     '404.description': 'A página que você procura não existe ou foi movida.',
     '404.cta': 'Voltar ao Início',
+
+    // Newsletter
+    'newsletter.heading': 'Receba os novos posts no seu inbox',
+    'newsletter.intro':
+      'Notas práticas sobre desenvolvimento assistido por IA, ferramentas e os sistemas por trás. Um email quando sai um post novo, sem spam.',
+    'newsletter.emailLabel': 'E-mail',
+    'newsletter.emailPlaceholder': 'voce@email.com',
+    'newsletter.submit': 'Inscrever-se',
+    'newsletter.hint':
+      'Você vai receber um email para confirmar o endereço. Pode cancelar a inscrição quando quiser.',
   },
 } as const satisfies Record<Lang, Record<string, string>>;
 

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -17,6 +17,7 @@ import TableOfContents from '@components/blog/TableOfContents.astro';
 import RelatedPosts from '@components/blog/RelatedPosts.astro';
 import AuthorBio from '@components/blog/AuthorBio.astro';
 import SocialShare from '@components/blog/SocialShare.astro';
+import SubscribeForm from '@components/blog/SubscribeForm.astro';
 import ReadingProgress from '@components/blog/ReadingProgress.astro';
 import { getReadingTime } from '@utils/readingTime';
 import { extractToc } from '@utils/toc';
@@ -261,6 +262,8 @@ const blogPostingSchema = generateBlogPostingSchema({
             />
 
             <AuthorBio name={data.author} lang={data.lang} />
+
+            <SubscribeForm lang={data.lang} />
           </div>
         </div>
 


### PR DESCRIPTION
## Summary

Adds a per-language newsletter subscribe form at the end of every blog post. Form posts directly to Listmonk's hosted `/subscription/form` endpoint on `newsletter.jjuanrivvera.com` with a hidden `list_uuid` per language. No JS or CORS required.

Listmonk handles the response page and double-opt-in confirmation email. Listmonk is deployed on the Pi (Docker, behind home tunnel) using Resend as SMTP relay. DNS already configured (Phase 1) and Listmonk verified for jjuanrivvera.com.

## What's new

- \`src/components/blog/SubscribeForm.astro\` — reusable form component with i18n
- \`src/layouts/PostLayout.astro\` — placement after AuthorBio
- \`src/i18n/ui.ts\` — \`newsletter.*\` keys for en/es/pt
- \`docs/proposals/newsletter-status.md\` — Phase 1 + 2 deployment notes (DNS, Listmonk, Resend, lists, credentials inventory)

## Test plan

- [ ] Open any blog post in en/es/pt — confirm SubscribeForm renders below AuthorBio
- [ ] Submit a real email — should redirect to Listmonk's success page (new tab)
- [ ] Confirmation email arrives from \`newsletter@jjuanrivvera.com\`
- [ ] Clicking confirm link adds the subscriber to the matching language list in Listmonk
- [ ] Mobile layout: form stacks vertically (button full-width)
- [ ] No console errors, no CORS errors, no failed network requests

## What's still pending (separate PRs)

- Phase 3 server-side endpoint (only if/when we want first-party POST instead of cross-origin)
- Phase 4 content workflow (auto-send campaign on blog merge)
- Cloudflare Turnstile (currently relying on Listmonk's built-in spam filter)

## Notes for review

- Cross-origin form POST works without CORS because browsers treat HTML form submits as "simple requests" (no preflight). Only fetch/XHR cross-origin needs CORS.
- The form opens response in a new tab (\`target="_blank"\`) so the reader keeps their place in the post.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Newsletter subscription form integrated into blog posts with support for English, Spanish, and Portuguese
  * Double opt-in email verification included for subscriber security
  * CAPTCHA protection enabled on subscription form

* **Documentation**
  * Added newsletter implementation status guide

<!-- end of auto-generated comment: release notes by coderabbit.ai -->