### PR TITLE
fix(blog): subscribe form altcha auto-solve + canvas-cli pubDate

### DIFF
--- a/src/components/blog/SubscribeForm.astro
+++ b/src/components/blog/SubscribeForm.astro
@@ -83,6 +83,8 @@ const subscribeApiUrl = `${listmonkOrigin}/api/public/subscription`;
       <altcha-widget
         challengeurl={altchaChallengeUrl}
         class="subscribe-form__altcha"
+        auto="onload"
+        floating="false"
         hidefooter
         hidelogo></altcha-widget>
 
@@ -131,20 +133,46 @@ const subscribeApiUrl = `${listmonkOrigin}/api/public/subscription`;
         feedback!.classList.toggle('subscribe-form__feedback--err', !ok);
       }
 
-      form.addEventListener('submit', async (event) => {
-        const altchaInput = form.querySelector<HTMLInputElement>(
+      function getAltchaValue(): string | null {
+        const input = form.querySelector<HTMLInputElement>(
           'input[name="altcha"]'
         );
-        const altcha = altchaInput?.value;
-        if (!altcha) {
-          // Altcha widget hasn't finished or failed to load — let the
-          // native form submit (cross-origin to Listmonk's hosted form).
-          return;
-        }
+        const v = input?.value;
+        return v && v.length > 0 ? v : null;
+      }
 
+      function waitForAltcha(timeoutMs: number): Promise<string | null> {
+        const existing = getAltchaValue();
+        if (existing) return Promise.resolve(existing);
+        return new Promise((resolve) => {
+          const widget = form.querySelector('altcha-widget');
+          let done = false;
+          const finish = (val: string | null) => {
+            if (done) return;
+            done = true;
+            widget?.removeEventListener('verified', onVerified);
+            resolve(val);
+          };
+          const onVerified = () => finish(getAltchaValue());
+          widget?.addEventListener('verified', onVerified);
+          setTimeout(() => finish(getAltchaValue()), timeoutMs);
+        });
+      }
+
+      form.addEventListener('submit', async (event) => {
+        // Always handle via fetch so the reader stays on the post; the
+        // cross-origin form action remains as a hard fallback if JS is
+        // blocked entirely.
         event.preventDefault();
         button.disabled = true;
         feedback.hidden = true;
+
+        const altcha = await waitForAltcha(5000);
+        if (!altcha) {
+          showFeedback(errorMsg, false);
+          button.disabled = false;
+          return;
+        }
 
         try {
           const res = await fetch(apiUrl, {

--- a/src/components/blog/SubscribeForm.astro
+++ b/src/components/blog/SubscribeForm.astro
@@ -101,7 +101,7 @@ const subscribeApiUrl = `${listmonkOrigin}/api/public/subscription`;
   </div>
 </aside>
 
-<script is:inline src={altchaScriptUrl} type="module" async></script>
+<script is:inline src={altchaScriptUrl} async></script>
 
 <script>
   // Progressive enhancement: intercept submit, post via fetch to keep the

--- a/src/content/blog/en/canvas-cli-the-complete-guide.md
+++ b/src/content/blog/en/canvas-cli-the-complete-guide.md
@@ -1,7 +1,7 @@
 ---
 title: 'Canvas CLI: The Complete Guide to LMS Automation'
 description: 'Master Canvas LMS automation with Canvas CLI. Learn installation, OAuth setup, batch operations, shell scripting, and advanced workflows for administrators.'
-pubDate: 2025-01-20
+pubDate: 2026-01-20
 author: 'Juan Felipe Rivera González'
 tags: ['go', 'canvas-lms', 'cli', 'automation', 'ai-agents']
 cover: '@assets/blog/covers/canvas-cli-guide-cover.jpg'

--- a/src/content/blog/es/canvas-cli-la-guia-completa.md
+++ b/src/content/blog/es/canvas-cli-la-guia-completa.md
@@ -1,7 +1,7 @@
 ---
 title: 'Canvas CLI: La Guía Completa para Automatización de LMS'
 description: 'Domina la automatización de Canvas LMS con Canvas CLI. Aprende instalación, OAuth, operaciones por lotes y flujos de trabajo avanzados.'
-pubDate: 2025-01-20
+pubDate: 2026-01-20
 author: 'Juan Felipe Rivera González'
 tags: ['go', 'canvas-lms', 'cli', 'automation', 'ai-agents']
 cover: '@assets/blog/covers/canvas-cli-guide-cover.jpg'

--- a/src/content/blog/pt/canvas-cli-o-guia-completo.md
+++ b/src/content/blog/pt/canvas-cli-o-guia-completo.md
@@ -1,7 +1,7 @@
 ---
 title: 'Canvas CLI: O Guia Completo para Automação de LMS'
 description: 'Domine a automação do Canvas LMS com Canvas CLI. Aprenda instalação, OAuth, operações em lote e fluxos de trabalho avançados.'
-pubDate: 2025-01-20
+pubDate: 2026-01-20
 author: 'Juan Felipe Rivera González'
 tags: ['go', 'canvas-lms', 'cli', 'automation', 'ai-agents']
 cover: '@assets/blog/covers/canvas-cli-guide-cover.jpg'

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -128,7 +128,7 @@ const {
     <!-- Content Security Policy (frame-ancestors set via HTTP header in netlify.toml) -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com https://static.cloudflareinsights.com https://newsletter.jjuanrivvera.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' https://www.google-analytics.com https://cloudflareinsights.com https://newsletter.jjuanrivvera.com; form-action 'self' https://newsletter.jjuanrivvera.com;"
+      content="default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com https://static.cloudflareinsights.com https://newsletter.jjuanrivvera.com; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' https://www.google-analytics.com https://cloudflareinsights.com https://newsletter.jjuanrivvera.com; form-action 'self' https://newsletter.jjuanrivvera.com;"
     />
 
     <!-- Author -->

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -128,7 +128,7 @@ const {
     <!-- Content Security Policy (frame-ancestors set via HTTP header in netlify.toml) -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' https://www.google-analytics.com https://cloudflareinsights.com; form-action 'self';"
+      content="default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com https://static.cloudflareinsights.com https://newsletter.jjuanrivvera.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' https://www.google-analytics.com https://cloudflareinsights.com https://newsletter.jjuanrivvera.com; form-action 'self' https://newsletter.jjuanrivvera.com;"
     />
 
     <!-- Author -->


### PR DESCRIPTION
## Summary

Two fixes bundled.

### 1. Subscribe form: dark page on submit

User reports kept seeing a blank/dark page in a new tab after clicking Subscribe, even after PR #60 added inline fetch handling. Root cause: the altcha widget required a user click on the visible "I'm not a robot" checkbox to start solving. If the reader hit Subscribe first, the JS handler bailed out (no altcha solution available) and the native cross-origin form POST kicked in, opening Listmonk's hosted response page in a new tab — which rendered as a black/blank screen on mobile Chrome.

Changes:
- \`altcha-widget\` now uses \`auto="onload"\` so the proof-of-work solves invisibly when the widget loads. No checkbox click required.
- Submit handler always calls \`preventDefault()\` regardless of altcha state. If the solution isn't ready yet, it awaits the widget's \`verified\` event (5s timeout) before posting.
- On timeout, shows the inline error message instead of falling back to the cross-origin POST.

The native \`<form action>\` is preserved as a hard no-JS fallback, but readers with JS always see inline feedback.

### 2. Canvas CLI pubDate

The Canvas CLI guide post had \`pubDate: 2025-01-20\` in all three locales (off by one year). Corrected to \`2026-01-20\` in en/es/pt.

## Test plan

- [ ] Open any blog post, do not interact with the altcha widget
- [ ] Watch network: \`/api/public/captcha/altcha\` should be fetched, widget solves silently within ~2-3s
- [ ] Type email → Subscribe → inline success message appears under the widget
- [ ] No new tab opens
- [ ] Submit before widget solves: button shows progress cursor briefly, success message still appears
- [ ] Subscribe with same email twice → second attempt shows "already on the list"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved form submission stability with enhanced error handling
* **Chores**
  * Updated blog post publication dates across multiple languages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->