### PR TITLE
blog: fix agent-first post pubDate to 2026-06-15

### DIFF
--- a/src/content/blog/en/how-i-built-an-agent-first-accounting-cli.md
+++ b/src/content/blog/en/how-i-built-an-agent-first-accounting-cli.md
@@ -1,7 +1,7 @@
 ---
 title: 'How I built an agent-first CLI for an accounting system'
 description: 'I built alegra-cli in a week with Claude Code. The speed came from high standards, enforcement in CI, and two workflows: /goal and /code-review.'
-pubDate: 2026-06-21
+pubDate: 2026-06-15
 author: 'Juan Felipe Rivera González'
 tags: ['ai-agents', 'cli', 'alegra', 'mcp', 'alegra-mcp']
 cover: '@assets/blog/covers/agent-first-cli-cover.jpg'

--- a/src/content/blog/es/como-construi-una-cli-agent-first-para-contabilidad.md
+++ b/src/content/blog/es/como-construi-una-cli-agent-first-para-contabilidad.md
@@ -1,7 +1,7 @@
 ---
 title: 'Cómo construí una CLI agent-first para un sistema contable'
 description: 'Construí alegra-cli en una semana con Claude Code. La velocidad vino de estándares altos, enforcement en CI y dos comandos: /goal y /code-review.'
-pubDate: 2026-06-21
+pubDate: 2026-06-15
 author: 'Juan Felipe Rivera González'
 tags: ['agentes-de-ia', 'cli', 'alegra', 'mcp', 'alegra-mcp']
 cover: '@assets/blog/covers/agent-first-cli-cover.jpg'

--- a/src/content/blog/pt/como-construi-uma-cli-agent-first-para-contabilidade.md
+++ b/src/content/blog/pt/como-construi-uma-cli-agent-first-para-contabilidade.md
@@ -1,7 +1,7 @@
 ---
 title: 'Como construí uma CLI agent-first para um sistema contábil'
 description: 'Construí o alegra-cli em uma semana com Claude Code. A velocidade veio de padrões altos, enforcement no CI e dois comandos: /goal e /code-review.'
-pubDate: 2026-06-21
+pubDate: 2026-06-15
 author: 'Juan Felipe Rivera González'
 tags: ['agentes-de-ia', 'cli', 'alegra', 'mcp', 'alegra-mcp']
 cover: '@assets/blog/covers/agent-first-cli-cover.jpg'


### PR DESCRIPTION
The post shipped with a placeholder `pubDate: 2026-06-21` (future), which dated it wrong on the site and blocked the newsletter (the publish script skips future-dated posts). Corrected to today's date across EN/ES/PT.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected publication dates on blog posts across English, Spanish, and Portuguese versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->